### PR TITLE
mobile version for footer

### DIFF
--- a/web/src/components/Footer/Footer.jsx
+++ b/web/src/components/Footer/Footer.jsx
@@ -1,22 +1,21 @@
 "use client";
 import styles from "./page.module.css";
 import Link from "next/link";
-
-//all links are disabled for now
+import { Facebook, Twitter, Instagram, Linkedin } from "lucide-react";
 
 export default function Footer() {
   return (
     <footer className={styles.footer}>
-      <div>
+      <div className={styles.navigation}>
         <Link href="/">Home</Link>
         <Link href="/plants">All Plants</Link>
         <Link href="/help">Help</Link>
       </div>
-      <div>
-        <Link href="https://www.facebook.com"><div className={styles.facebook_icon}></div></Link>
-        <Link href="https://x.com"><div className={styles.twitter_icon}></div></Link>
-        <Link href="https://www.instagram.com"><div className={styles.instagram_icon}></div></Link>
-        <Link href="https://www.linkedin.com"><div className={styles.linkedin_icon}></div></Link>
+      <div className={styles.links}>
+        <Link href="https://www.facebook.com"><Facebook className={styles.icon}/></Link>
+        <Link href="https://x.com"><Twitter className={styles.icon}/></Link>
+        <Link href="https://www.instagram.com"><Instagram className={styles.icon}/></Link>
+        <Link href="https://www.linkedin.com"><Linkedin className={styles.icon}/></Link>
       </div>
     </footer>
   );

--- a/web/src/components/Footer/page.module.css
+++ b/web/src/components/Footer/page.module.css
@@ -9,7 +9,7 @@
     background-color: #48A830FF;
 }
 
-.footer div{
+.navigation{
     display: flex;
     gap: 20px;
     color: white;
@@ -17,30 +17,26 @@
     text-decoration: none;
 }
 
-.facebook_icon{
-    width: 25px;
-    height: 25px;
-    background-color: white;
-    mask-image: url('/facebook_icon.svg');
+.links{
+    display: flex;
+    gap: 20px;
+    color: white;
+    font-weight: bold;
+    text-decoration: none;
 }
 
-.twitter_icon{
+.icon{
     width: 25px;
     height: 25px;
-    background-color: white;
-    mask-image: url('/twitter_icon.svg');
 }
 
-.instagram_icon{
-    width: 25px;
-    height: 25px;
-    background-color: white;
-    mask-image: url('/instagram_icon.svg');
-}
+@media (max-width: 768px){
+    .navigation{
+        display: none;
+    }
 
-.linkedin_icon{
-    width: 25px;
-    height: 25px;
-    background-color: white;
-    mask-image: url('/linkedin_icon.svg');
+    .links{
+        gap: 40px;
+        margin-left: auto;
+    }
 }


### PR DESCRIPTION
I edited the icons, so they are now not images, but icons from the lucide-react. Also made mobile version of the footer
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/b70983bd-2eff-4990-8fa3-7cf32bcb2406" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/73f5b7ae-55b3-41b3-82a4-6cc7a02d94bd" />
On the tablet devices (if they have screen bigger than 768px) the footer will be like on the desktop verison 